### PR TITLE
xpath: Update default iterator value for xpath

### DIFF
--- a/xpath/section/reference-formulation.md
+++ b/xpath/section/reference-formulation.md
@@ -15,7 +15,7 @@ The [=nodelist=] that is the result of evaluating the <a data-cite="RML-Core#dfn
 
 ### Default iterator
 
-The <a data-cite="RML-Core#dfn-default-iterator">default iterator</a>, if no <a data-cite="RML-Core#dfn-iterator">iterator</a> is specified for a <a data-cite="RML-Core#dfn-logical-source">logical source</a> with the [=XPath reference formulation=], MUST be the [=root node identifier=] `$`. This expression refers to the root node of the [=XML value=].
+The <a data-cite="RML-Core#dfn-default-iterator">default iterator</a>, if no <a data-cite="RML-Core#dfn-iterator">iterator</a> is specified for a <a data-cite="RML-Core#dfn-logical-source">logical source</a> with the [=XPath reference formulation=], MUST be the [=root node identifier=] `/`. This expression refers to the root node of the [=XML value=].
 
 ## Expressions
 


### PR DESCRIPTION
Updated the default iterator section of XPATH to use the correct root node identifier in xpath which is "/" 

For JSON, there is already a correct section for default JSONPath Iterator.
Fixes #3 