### PR TITLE
fix RMLIOREGTC0006e MSSQL DB Name

### DIFF
--- a/test-cases/RMLIOREGTC0006e/README.md
+++ b/test-cases/RMLIOREGTC0006e/README.md
@@ -8,8 +8,8 @@
 
 **Input**
 ```
-USE test;
-DROP TABLE IF EXISTS test.Person;
+USE TestDB;
+DROP TABLE IF EXISTS TestDB.Person;
 
 CREATE TABLE Person (
 ID integer,

--- a/test-cases/RMLIOREGTC0006e/resource.sql
+++ b/test-cases/RMLIOREGTC0006e/resource.sql
@@ -1,5 +1,5 @@
-USE test;
-DROP TABLE IF EXISTS test.Person;
+USE TestDB;
+DROP TABLE IF EXISTS TestDB.Person;
 
 CREATE TABLE Person (
 ID integer,


### PR DESCRIPTION
The test fails, but currently due to the incorrect DB Name, not the invalid SQL iterator. 