### PR TITLE
Fix #38 the default namespace applies by standards.

### DIFF
--- a/test-cases/RMLIOREGTC0003d/mapping.ttl
+++ b/test-cases/RMLIOREGTC0003d/mapping.ttl
@@ -3,11 +3,11 @@
 
 <http://example.com/base/TriplesMap1> a rml:TriplesMap;
   rml:logicalSource [ a rml:LogicalSource;
-      rml:iterator "/ex:students/student";
+      rml:iterator "/ex:students/ex:student";
       rml:referenceFormulation [ a rml:XPathReferenceFormulation;
         rml:namespace [ a rml:Namespace;
          rml:namespacePrefix "ex";
-         rml:namespaceURL "http://example.org";
+         rml:namespaceURL "http://example.org/";
        ];
       ];
       rml:source [ a rml:RelativePathSource;
@@ -17,10 +17,10 @@
     ];
   rml:predicateObjectMap [
       rml:objectMap [
-          rml:reference "Name"
+          rml:reference "ex:Name"
         ];
       rml:predicate foaf:name
     ];
   rml:subjectMap [
-      rml:template "http://example.com/{Name}"
+      rml:template "http://example.com/{ex:Name}"
     ] .


### PR DESCRIPTION
By using `xmlns="http://example.org/"` the default namespace applies to all elements in this source and needs to be reflected in the mapping.