### PR TITLE
fix: add missing foaf prefix to dbpedia query in RMLIOREGTC0011a

### DIFF
--- a/test-cases/RMLIOREGTC0011a/mapping.ttl
+++ b/test-cases/RMLIOREGTC0011a/mapping.ttl
@@ -16,6 +16,7 @@
       PREFIX dbo: <http://dbpedia.org/ontology/>
       PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+      PREFIX foaf: <http://xmlns.com/foaf/0.1/>
       SELECT DISTINCT ?actor ?name WHERE {
         ?tvshow rdf:type dbo:TelevisionShow .
         ?tvshow rdfs:label "The Big Bang Theory"@en .


### PR DESCRIPTION
Add the missing foaf prefix in the query.

But the issue with this test is that dbpedia.org data changes over time, and currently the expected output is not up-to-date, for example.