### PR TITLE
fix test 456k with unquoted identifiers

### DIFF
--- a/test-cases/RMLIOREGTC0004k/output.nq
+++ b/test-cases/RMLIOREGTC0004k/output.nq
@@ -1,1 +1,1 @@
-<http://example.com/10/Venus> <http://example.com/id> "10".
+<http://example.com/10/Venus> <http://example.com/id> "10"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLIOREGTC0005k/output.nq
+++ b/test-cases/RMLIOREGTC0005k/output.nq
@@ -1,1 +1,1 @@
-<http://example.com/10/Venus> <http://example.com/id> "10".
+<http://example.com/10/Venus> <http://example.com/id> "10"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLIOREGTC0005k/resource.sql
+++ b/test-cases/RMLIOREGTC0005k/resource.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS student CASCADE ;
 CREATE TABLE student (
-  "ID" INTEGER,
-  "Name" VARCHAR(50)
+  ID INTEGER,
+  Name VARCHAR(50)
 );
 INSERT INTO student values ('10', 'Venus');

--- a/test-cases/RMLIOREGTC0006k/output.nq
+++ b/test-cases/RMLIOREGTC0006k/output.nq
@@ -1,1 +1,1 @@
-<http://example.com/10/Venus> <http://example.com/id> "10".
+<http://example.com/10/Venus> <http://example.com/id> "10"^^<http://www.w3.org/2001/XMLSchema#integer>.


### PR DESCRIPTION
The 4k, 5k, 6k tests do not follow natural datatype and should not test for quoted identifiers as did 5k.