### PR TITLE
fix: 7a natural datatype from JSON, number to xsd:integer

### DIFF
--- a/test-cases/RMLIOREGTC0007a/output.nq
+++ b/test-cases/RMLIOREGTC0007a/output.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .


### PR DESCRIPTION
According to JSONPath datatype mapping, numbers should be converted to xsd:integer.