### PR TITLE
fix test 456l use qualified column names, not missing column

### DIFF
--- a/test-cases/RMLIOREGTC0004l/mapping.ttl
+++ b/test-cases/RMLIOREGTC0004l/mapping.ttl
@@ -4,7 +4,7 @@
 
 <http://example.com/base/TriplesMap1> a rml:TriplesMap;
   rml:logicalSource [
-      rml:iterator "SELECT NoColumnName, ID, Name FROM student";
+      rml:iterator "SELECT student.ID, student.Name FROM student";
       rml:referenceFormulation rml:SQL2008Query;
       rml:source <http://example.com/base/#DB_source>
     ];

--- a/test-cases/RMLIOREGTC0004l/output.nq
+++ b/test-cases/RMLIOREGTC0004l/output.nq
@@ -1,1 +1,1 @@
-<http://example.com/10/Venus> <http://example.com/id> "10".
+<http://example.com/10/Venus> <http://example.com/id> "10"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLIOREGTC0005l/mapping.ttl
+++ b/test-cases/RMLIOREGTC0005l/mapping.ttl
@@ -4,7 +4,7 @@
 
 <http://example.com/base/TriplesMap1> a rml:TriplesMap;
   rml:logicalSource [
-      rml:iterator "SELECT NoColumnName, ID, Name FROM student";
+      rml:iterator "SELECT student.ID, student.Name FROM student";
       rml:referenceFormulation rml:SQL2008Query;
       rml:source <http://example.com/base/#DB_source>
     ];

--- a/test-cases/RMLIOREGTC0005l/output.nq
+++ b/test-cases/RMLIOREGTC0005l/output.nq
@@ -1,1 +1,1 @@
-<http://example.com/10/Venus> <http://example.com/id> "10".
+<http://example.com/10/Venus> <http://example.com/id> "10"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLIOREGTC0005l/resource.sql
+++ b/test-cases/RMLIOREGTC0005l/resource.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS student CASCADE ;
 CREATE TABLE student (
-  "ID" INTEGER,
-  "Name" VARCHAR(50)
+  ID INTEGER,
+  Name VARCHAR(50)
 );
 INSERT INTO student values ('10', 'Venus');

--- a/test-cases/RMLIOREGTC0006l/README.md
+++ b/test-cases/RMLIOREGTC0006l/README.md
@@ -28,13 +28,13 @@ INSERT INTO student values ('10', 'Venus');
 
 <http://example.com/base/TriplesMap1> a rml:TriplesMap;
   rml:logicalSource [
-      rml:iterator "SELECT NoColumnName, ID, Name FROM student";
+      rml:iterator "SELECT student.ID, student.Name FROM student";
       rml:referenceFormulation rml:SQL2008Query;
       rml:source <http://example.com/base/#DB_source>
     ];
   rml:predicateObjectMap [
       rml:objectMap [
-          rml:reference "IDs"
+          rml:reference "ID"
         ];
       rml:predicate ex:id
     ];

--- a/test-cases/RMLIOREGTC0006l/mapping.ttl
+++ b/test-cases/RMLIOREGTC0006l/mapping.ttl
@@ -4,13 +4,13 @@
 
 <http://example.com/base/TriplesMap1> a rml:TriplesMap;
   rml:logicalSource [
-      rml:iterator "SELECT NoColumnName, ID, Name FROM student";
+      rml:iterator "SELECT student.ID, student.Name FROM student";
       rml:referenceFormulation rml:SQL2008Query;
       rml:source <http://example.com/base/#DB_source>
     ];
   rml:predicateObjectMap [
       rml:objectMap [
-          rml:reference "IDs"
+          rml:reference "ID"
         ];
       rml:predicate ex:id
     ];

--- a/test-cases/RMLIOREGTC0006l/output.nq
+++ b/test-cases/RMLIOREGTC0006l/output.nq
@@ -1,1 +1,1 @@
-<http://example.com/10/Venus> <http://example.com/id> "10".
+<http://example.com/10/Venus> <http://example.com/id> "10"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLIOREGTC0006l/resource.sql
+++ b/test-cases/RMLIOREGTC0006l/resource.sql
@@ -3,7 +3,7 @@ EXEC sp_msforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT all'
 EXEC sp_msforeachtable 'DROP TABLE ?'
 
 CREATE TABLE student (
-  "ID" INTEGER,
-  "Name" VARCHAR(50)
+  ID INTEGER,
+  Name VARCHAR(50)
 );
 INSERT INTO student values ('10', 'Venus');


### PR DESCRIPTION
The series of tests 4l, 5l, 6l mention in their description: *Two columns mapping, qualified column names*.
However I don't see qualified column names only delimited/quoted identifiers in 5l and 6l db defintions.

If the description is correct, I guess the tests should be more like the proposed `SELECT student.ID, student.Name FROM student` instead of the existing `SELECT NoColumnName, ID, Name FROM student`.

If accepted, we may need to check whether a test for a missing column exists besides this one.